### PR TITLE
Fix Decidim Namepsacing

### DIFF
--- a/lib/decidim/maintainers_toolbox/backporter.rb
+++ b/lib/decidim/maintainers_toolbox/backporter.rb
@@ -1,98 +1,100 @@
 # frozen_string_literal: true
 
-module Decidim::MaintainersToolbox
-  class Backporter
-    class InvalidMetadataError < StandardError; end
+module Decidim
+  module MaintainersToolbox
+    class Backporter
+      class InvalidMetadataError < StandardError; end
 
-    # @param token [String] token for GitHub authentication
-    # @param pull_request_id [String] the ID of the pull request that we want to backport
-    # @param version_number [String] the version number of the release that we want to make the backport to
-    # @param exit_with_unstaged_changes [Boolean] wheter we should exit cowardly if there is any unstaged change
-    def initialize(token:, pull_request_id:, version_number:, exit_with_unstaged_changes:)
-      @token = token
-      @pull_request_id = pull_request_id
-      @version_number = version_number
-      @exit_with_unstaged_changes = exit_with_unstaged_changes
-    end
+      # @param token [String] token for GitHub authentication
+      # @param pull_request_id [String] the ID of the pull request that we want to backport
+      # @param version_number [String] the version number of the release that we want to make the backport to
+      # @param exit_with_unstaged_changes [Boolean] wheter we should exit cowardly if there is any unstaged change
+      def initialize(token:, pull_request_id:, version_number:, exit_with_unstaged_changes:)
+        @token = token
+        @pull_request_id = pull_request_id
+        @version_number = version_number
+        @exit_with_unstaged_changes = exit_with_unstaged_changes
+      end
 
-    # Handles the different tasks to create a backport:
-    # * Gets the metadata of a pull request on GitHub
-    # * Appls thi commit to another brach and push it to the remote repository
-    # * Creates the pull request on GitHub
-    #
-    # @raise [InvalidMetadataError] if we could not get the information of this pull quest
-    # @return [void]
-    def call
-      metadata = pull_request_metadata
-      make_cherrypick_and_branch(metadata)
-      create_pull_request(metadata)
-      Decidim::MaintainersToolbox::GitBackportManager.checkout_develop
-    end
+      # Handles the different tasks to create a backport:
+      # * Gets the metadata of a pull request on GitHub
+      # * Appls thi commit to another brach and push it to the remote repository
+      # * Creates the pull request on GitHub
+      #
+      # @raise [InvalidMetadataError] if we could not get the information of this pull quest
+      # @return [void]
+      def call
+        metadata = pull_request_metadata
+        make_cherrypick_and_branch(metadata)
+        create_pull_request(metadata)
+        Decidim::MaintainersToolbox::GitBackportManager.checkout_develop
+      end
 
-    private
+      private
 
-    attr_reader :token, :pull_request_id, :version_number, :exit_with_unstaged_changes
+      attr_reader :token, :pull_request_id, :version_number, :exit_with_unstaged_changes
 
-    # Asks the metadata for a given issue or pull request on GitHub API
-    #
-    # @return [Faraday::Response] An instance that represents an HTTP response from making an HTTP request
-    def pull_request_metadata
-      Decidim::MaintainersToolbox::GithubManager::Querier::ByIssueId.new(
-        token: token,
-        issue_id: pull_request_id
-      ).call
-    end
+      # Asks the metadata for a given issue or pull request on GitHub API
+      #
+      # @return [Faraday::Response] An instance that represents an HTTP response from making an HTTP request
+      def pull_request_metadata
+        Decidim::MaintainersToolbox::GithubManager::Querier::ByIssueId.new(
+          token: token,
+          issue_id: pull_request_id
+        ).call
+      end
 
-    # Handles all the different tasks involved on a backport with the git command line utility
-    #
-    # @return [void]
-    def make_cherrypick_and_branch(metadata)
-      Decidim::MaintainersToolbox::GitBackportManager.new(
-        pull_request_id: pull_request_id,
-        release_branch: release_branch,
-        backport_branch: backport_branch(metadata[:title]),
-        exit_with_unstaged_changes: exit_with_unstaged_changes
-      ).call
-    end
+      # Handles all the different tasks involved on a backport with the git command line utility
+      #
+      # @return [void]
+      def make_cherrypick_and_branch(metadata)
+        Decidim::MaintainersToolbox::GitBackportManager.new(
+          pull_request_id: pull_request_id,
+          release_branch: release_branch,
+          backport_branch: backport_branch(metadata[:title]),
+          exit_with_unstaged_changes: exit_with_unstaged_changes
+        ).call
+      end
 
-    # Creates the pull request with GitHub API
-    #
-    # @return [Faraday::Response] An instance that represents an HTTP response from making an HTTP request
-    def create_pull_request(metadata)
-      params = {
-        title: "Backport '#{metadata[:title]}' to v#{version_number}",
-        body: "#### :tophat: What? Why?\n\nBackport ##{pull_request_id} to v#{version_number}\n\n:hearts: Thank you!",
-        labels: (metadata[:labels] << "backport"),
-        head: backport_branch(metadata[:title]),
-        base: release_branch
-      }
+      # Creates the pull request with GitHub API
+      #
+      # @return [Faraday::Response] An instance that represents an HTTP response from making an HTTP request
+      def create_pull_request(metadata)
+        params = {
+          title: "Backport '#{metadata[:title]}' to v#{version_number}",
+          body: "#### :tophat: What? Why?\n\nBackport ##{pull_request_id} to v#{version_number}\n\n:hearts: Thank you!",
+          labels: (metadata[:labels] << "backport"),
+          head: backport_branch(metadata[:title]),
+          base: release_branch
+        }
 
-      Decidim::MaintainersToolbox::GithubManager::Poster.new(
-        token: token,
-        params: params
-      ).call
-    end
+        Decidim::MaintainersToolbox::GithubManager::Poster.new(
+          token: token,
+          params: params
+        ).call
+      end
 
-    # Name of the release branch
-    #
-    # @return [String] name of the release branch
-    def release_branch
-      "release/#{version_number}-stable"
-    end
+      # Name of the release branch
+      #
+      # @return [String] name of the release branch
+      def release_branch
+        "release/#{version_number}-stable"
+      end
 
-    # Name of the backport branch
-    #
-    # @return [String] name of the backport branch
-    def backport_branch(pull_request_title)
-      "backport/#{version_number}/#{slugify(pull_request_title).slice!(0, 30)}-#{pull_request_id}"
-    end
+      # Name of the backport branch
+      #
+      # @return [String] name of the backport branch
+      def backport_branch(pull_request_title)
+        "backport/#{version_number}/#{slugify(pull_request_title).slice!(0, 30)}-#{pull_request_id}"
+      end
 
-    # Converts a string with spaces to a slug
-    # It changes it to lowercase and removes spaces
-    #
-    # @return [String] slugged string
-    def slugify(string)
-      string.downcase.strip.gsub(" ", "-").gsub(/[^\w-]/, "")
+      # Converts a string with spaces to a slug
+      # It changes it to lowercase and removes spaces
+      #
+      # @return [String] slugged string
+      def slugify(string)
+        string.downcase.strip.gsub(" ", "-").gsub(/[^\w-]/, "")
+      end
     end
   end
 end

--- a/lib/decidim/maintainers_toolbox/backports_reporter/cli_report.rb
+++ b/lib/decidim/maintainers_toolbox/backports_reporter/cli_report.rb
@@ -3,41 +3,43 @@
 require "active_support/core_ext/string/filters"
 require_relative "report"
 
-module Decidim::MaintainersToolbox
-  module BackportsReporter
-    class CLIReport < Decidim::MaintainersToolbox::BackportsReporter::Report
-      private
+module Decidim
+  module MaintainersToolbox
+    module BackportsReporter
+      class CLIReport < Decidim::MaintainersToolbox::BackportsReporter::Report
+        private
 
-      def output_head
-        head = "| #{"ID".center(6)} | #{"Title".center(83)} | Backport v#{last_version_number} | Backport v#{penultimate_version_number} |\n"
-        head += "|#{"-" * 8}|#{"-" * 85}|#{"-" * 16}|#{"-" * 16}|\n"
-        head
-      end
+        def output_head
+          head = "| #{"ID".center(6)} | #{"Title".center(83)} | Backport v#{last_version_number} | Backport v#{penultimate_version_number} |\n"
+          head += "|#{"-" * 8}|#{"-" * 85}|#{"-" * 16}|#{"-" * 16}|\n"
+          head
+        end
 
-      def output_line(line)
-        output = "| ##{line[:id].to_s.center(5)} "
-        output += "| #{line[:title].truncate(83).ljust(84, " ")}"
-        output += "| #{format_backport(line[:related_issues], "v#{last_version_number}")}"
-        output += "| #{format_backport(line[:related_issues], "v#{penultimate_version_number}")}|\n"
-        output
-      end
+        def output_line(line)
+          output = "| ##{line[:id].to_s.center(5)} "
+          output += "| #{line[:title].truncate(83).ljust(84, " ")}"
+          output += "| #{format_backport(line[:related_issues], "v#{last_version_number}")}"
+          output += "| #{format_backport(line[:related_issues], "v#{penultimate_version_number}")}|\n"
+          output
+        end
 
-      def format_backport(related_issues, version)
-        none = "None".center(15, " ")
-        return none if related_issues.empty?
+        def format_backport(related_issues, version)
+          none = "None".center(15, " ")
+          return none if related_issues.empty?
 
-        pull_request = extract_backport_pull_request_for_version(related_issues, version)
-        return none if pull_request.nil?
+          pull_request = extract_backport_pull_request_for_version(related_issues, version)
+          return none if pull_request.nil?
 
-        "\e[#{state_color(pull_request[:state])}m##{pull_request[:id]}\e[0m".center(24, " ")
-      end
+          "\e[#{state_color(pull_request[:state])}m##{pull_request[:id]}\e[0m".center(24, " ")
+        end
 
-      def state_color(state)
-        {
-          closed: "35",
-          merged: "34",
-          open: "32"
-        }[state.to_sym]
+        def state_color(state)
+          {
+            closed: "35",
+            merged: "34",
+            open: "32"
+          }[state.to_sym]
+        end
       end
     end
   end

--- a/lib/decidim/maintainers_toolbox/backports_reporter/csv_report.rb
+++ b/lib/decidim/maintainers_toolbox/backports_reporter/csv_report.rb
@@ -2,30 +2,32 @@
 
 require_relative "report"
 
-module Decidim::MaintainersToolbox
-  module BackportsReporter
-    class CSVReport < Decidim::MaintainersToolbox::BackportsReporter::Report
-      private
+module Decidim
+  module MaintainersToolbox
+    module BackportsReporter
+      class CSVReport < Decidim::MaintainersToolbox::BackportsReporter::Report
+        private
 
-      def output_head
-        "ID;Title;Backport v#{last_version_number};Backport v#{penultimate_version_number}\n"
-      end
+        def output_head
+          "ID;Title;Backport v#{last_version_number};Backport v#{penultimate_version_number}\n"
+        end
 
-      def output_line(line)
-        output = "#{line[:id]};"
-        output += "#{line[:title]};"
-        output += "#{format_backport(line[:related_issues], "v#{last_version_number}")};"
-        output += "#{format_backport(line[:related_issues], "v#{penultimate_version_number}")}\n"
-        output
-      end
+        def output_line(line)
+          output = "#{line[:id]};"
+          output += "#{line[:title]};"
+          output += "#{format_backport(line[:related_issues], "v#{last_version_number}")};"
+          output += "#{format_backport(line[:related_issues], "v#{penultimate_version_number}")}\n"
+          output
+        end
 
-      def format_backport(related_issues, version)
-        return if related_issues.empty?
+        def format_backport(related_issues, version)
+          return if related_issues.empty?
 
-        pull_request = extract_backport_pull_request_for_version(related_issues, version)
-        return if pull_request.nil?
+          pull_request = extract_backport_pull_request_for_version(related_issues, version)
+          return if pull_request.nil?
 
-        "#{pull_request[:state]}|#{pull_request[:id]}"
+          "#{pull_request[:state]}|#{pull_request[:id]}"
+        end
       end
     end
   end

--- a/lib/decidim/maintainers_toolbox/backports_reporter/report.rb
+++ b/lib/decidim/maintainers_toolbox/backports_reporter/report.rb
@@ -1,51 +1,53 @@
 # frozen_string_literal: true
 
-module Decidim::MaintainersToolbox
-  module BackportsReporter
-    # Abstract class for the different formats
-    class Report
-      attr_reader :report, :last_version_number
+module Decidim
+  module MaintainersToolbox
+    module BackportsReporter
+      # Abstract class for the different formats
+      class Report
+        attr_reader :report, :last_version_number
 
-      def initialize(report:, last_version_number:)
-        @report = report
-        @last_version_number = last_version_number
-      end
-
-      def call
-        output_report
-      end
-
-      private
-
-      def penultimate_version_number
-        major, minor = last_version_number.split(".")
-
-        "#{major}.#{minor.to_i - 1}"
-      end
-
-      def output_report
-        output = output_head
-        report.each do |line|
-          output += output_line(line)
+        def initialize(report:, last_version_number:)
+          @report = report
+          @last_version_number = last_version_number
         end
-        output
-      end
 
-      def output_head
-        raise "Called abstract method: output_head"
-      end
-
-      def output_line(_line)
-        raise "Called abstract method: output_line"
-      end
-
-      def extract_backport_pull_request_for_version(related_issues, version)
-        related_issues = related_issues.select do |pull_request|
-          pull_request[:title].start_with?("Backport") && pull_request[:title].include?(version)
+        def call
+          output_report
         end
-        return if related_issues.empty?
 
-        related_issues.first
+        private
+
+        def penultimate_version_number
+          major, minor = last_version_number.split(".")
+
+          "#{major}.#{minor.to_i - 1}"
+        end
+
+        def output_report
+          output = output_head
+          report.each do |line|
+            output += output_line(line)
+          end
+          output
+        end
+
+        def output_head
+          raise "Called abstract method: output_head"
+        end
+
+        def output_line(_line)
+          raise "Called abstract method: output_line"
+        end
+
+        def extract_backport_pull_request_for_version(related_issues, version)
+          related_issues = related_issues.select do |pull_request|
+            pull_request[:title].start_with?("Backport") && pull_request[:title].include?(version)
+          end
+          return if related_issues.empty?
+
+          related_issues.first
+        end
       end
     end
   end

--- a/lib/decidim/maintainers_toolbox/changelog_generator.rb
+++ b/lib/decidim/maintainers_toolbox/changelog_generator.rb
@@ -5,160 +5,162 @@ require_relative "github_manager/querier"
 require "json"
 require "ruby-progressbar"
 
-module Decidim::MaintainersToolbox
-  class ChangeLogGenerator
-    class InvalidMetadataError < StandardError; end
+module Decidim
+  module MaintainersToolbox
+    class ChangeLogGenerator
+      class InvalidMetadataError < StandardError; end
 
-    TYPES = {
-      "Added" => {
-        label: "type: feature",
-        skip_modules: false
-      },
-      "Changed" => {
-        label: "type: change",
-        skip_modules: false
-      },
-      "Fixed" => {
-        label: "type: fix",
-        skip_modules: false
-      },
-      "Removed" => {
-        label: "type: removal",
-        skip_modules: false
-      },
-      "Developer improvements" => {
-        label: "target: developer-experience",
-        skip_modules: true
-      },
-      "Internal" => {
-        label: "type: internal",
-        skip_modules: false
-      }
-    }.freeze
+      TYPES = {
+        "Added" => {
+          label: "type: feature",
+          skip_modules: false
+        },
+        "Changed" => {
+          label: "type: change",
+          skip_modules: false
+        },
+        "Fixed" => {
+          label: "type: fix",
+          skip_modules: false
+        },
+        "Removed" => {
+          label: "type: removal",
+          skip_modules: false
+        },
+        "Developer improvements" => {
+          label: "target: developer-experience",
+          skip_modules: true
+        },
+        "Internal" => {
+          label: "type: internal",
+          skip_modules: false
+        }
+      }.freeze
 
-    def initialize(token:, since_sha:)
-      @token = token
-      @since_sha = since_sha
-      @output_file = []
-      @handled_ids = []
+      def initialize(token:, since_sha:)
+        @token = token
+        @since_sha = since_sha
+        @output_file = []
+        @handled_ids = []
 
-      @progress_bar = ProgressBar.create(title: "PRs", total: list_of_commits.count)
-    end
+        @progress_bar = ProgressBar.create(title: "PRs", total: list_of_commits.count)
+      end
 
-    def call
-      raise InvalidMetadataError if token.nil?
+      def call
+        raise InvalidMetadataError if token.nil?
 
-      TYPES.each do |type_title, type_data|
-        type_prs = prs.select do |_commit_title, data|
-          next unless data
+        TYPES.each do |type_title, type_data|
+          type_prs = prs.select do |_commit_title, data|
+            next unless data
 
-          data[:type].include?(type_data[:label])
-        end
-
-        output "### #{type_title}"
-        output ""
-
-        if type_prs.any?
-          type_prs.each do |_pr_title, data|
-            process_single_pr(data, type_data)
+            data[:type].include?(type_data[:label])
           end
-        else
-          output "Nothing."
+
+          output "### #{type_title}"
+          output ""
+
+          if type_prs.any?
+            type_prs.each do |_pr_title, data|
+              process_single_pr(data, type_data)
+            end
+          else
+            output "Nothing."
+          end
+
+          output ""
         end
 
+        process_unsorted_prs
+        write_data_file!
+      end
+
+      private
+
+      def write_data_file!
+        File.write("temporary_changelog.md", @output_file.join("\n"))
+        puts "Written file: temporary_changelog.md"
+      end
+
+      def process_single_pr(data, type_data)
+        modules_list = data[:modules].map { |l| "**decidim-#{l.delete_prefix("module: ")}**" }
+        id = data[:id]
+        title = data[:title]
+
+        @handled_ids << id
+
+        if type_data[:skip_modules] || modules_list.empty?
+          output "- #{title} #{pr_link(id)}"
+        else
+          output "- #{modules_list.join(", ")}: #{title} #{pr_link(id)}"
+        end
+      end
+
+      def process_unsorted_prs
+        return unless unsorted_prs.any?
+
+        output "### Unsorted"
         output ""
+
+        unsorted_prs.map do |title, data|
+          pr_data = data || {}
+          output "- #{title} #{pr_link(pr_data[:id])} || #{data}"
+        end
       end
 
-      process_unsorted_prs
-      write_data_file!
-    end
+      def unsorted_prs
+        @unsorted_prs ||= prs.reject do |_commit_title, data|
+          pr_data = data || {}
 
-    private
-
-    def write_data_file!
-      File.write("temporary_changelog.md", @output_file.join("\n"))
-      puts "Written file: temporary_changelog.md"
-    end
-
-    def process_single_pr(data, type_data)
-      modules_list = data[:modules].map { |l| "**decidim-#{l.delete_prefix("module: ")}**" }
-      id = data[:id]
-      title = data[:title]
-
-      @handled_ids << id
-
-      if type_data[:skip_modules] || modules_list.empty?
-        output "- #{title} #{pr_link(id)}"
-      else
-        output "- #{modules_list.join(", ")}: #{title} #{pr_link(id)}"
+          @handled_ids.include?(pr_data[:id])
+        end
       end
-    end
 
-    def process_unsorted_prs
-      return unless unsorted_prs.any?
+      attr_reader :token, :since_sha
 
-      output "### Unsorted"
-      output ""
+      def prs
+        @prs ||= list_of_commits.inject({}) do |acc, commit|
+          next acc if crowdin?(commit)
 
-      unsorted_prs.map do |title, data|
-        pr_data = data || {}
-        output "- #{title} #{pr_link(pr_data[:id])} || #{data}"
+          acc.update(commit => get_pr_data(commit))
+        end
       end
-    end
 
-    def unsorted_prs
-      @unsorted_prs ||= prs.reject do |_commit_title, data|
-        pr_data = data || {}
-
-        @handled_ids.include?(pr_data[:id])
+      def list_of_commits
+        @list_of_commits ||= `git log #{since_sha}..HEAD --oneline`.split("\n").reverse
       end
-    end
 
-    attr_reader :token, :since_sha
-
-    def prs
-      @prs ||= list_of_commits.inject({}) do |acc, commit|
-        next acc if crowdin?(commit)
-
-        acc.update(commit => get_pr_data(commit))
+      def crowdin?(commit)
+        !commit.match(/New Crowdin updates/).nil?
       end
-    end
 
-    def list_of_commits
-      @list_of_commits ||= `git log #{since_sha}..HEAD --oneline`.split("\n").reverse
-    end
+      def get_pr_id(commit)
+        id = commit.scan(/#\d+/).last
+        return unless id
 
-    def crowdin?(commit)
-      !commit.match(/New Crowdin updates/).nil?
-    end
+        id.delete_prefix("#")
+      end
 
-    def get_pr_id(commit)
-      id = commit.scan(/#\d+/).last
-      return unless id
+      def get_pr_data(commit)
+        @progress_bar.increment
 
-      id.delete_prefix("#")
-    end
+        id = get_pr_id(commit)
+        return nil unless id
 
-    def get_pr_data(commit)
-      @progress_bar.increment
+        Decidim::MaintainersToolbox::GithubManager::Querier::ByIssueId.new(
+          token: token,
+          issue_id: id
+        ).call
+      end
 
-      id = get_pr_id(commit)
-      return nil unless id
+      def pr_link(id)
+        # We need to do this so that it generates the expected Markdown format.
+        # String interpolation messes with the format.
+        "[#{"\\#" + id.to_s}](https://github.com/decidim/decidim/pull/#{id})" # rubocop:disable Style/StringConcatenation
+      end
 
-      Decidim::MaintainersToolbox::GithubManager::Querier::ByIssueId.new(
-        token: token,
-        issue_id: id
-      ).call
-    end
-
-    def pr_link(id)
-      # We need to do this so that it generates the expected Markdown format.
-      # String interpolation messes with the format.
-      "[#{"\\#" + id.to_s}](https://github.com/decidim/decidim/pull/#{id})" # rubocop:disable Style/StringConcatenation
-    end
-
-    def output(str)
-      @output_file << str
+      def output(str)
+        @output_file << str
+      end
     end
   end
 end

--- a/lib/decidim/maintainers_toolbox/git_backport_checker.rb
+++ b/lib/decidim/maintainers_toolbox/git_backport_checker.rb
@@ -7,73 +7,75 @@ require_relative "github_manager/querier/related_issues"
 require_relative "backports_reporter/csv_report"
 require_relative "backports_reporter/cli_report"
 
-module Decidim::MaintainersToolbox
-  # Extracts the status of the Pull Requests on the decidim repository
-  # with the label "type: fix" and shows the status of the related Pull Requests,
-  # so we can check which PRs have pending backports
-  class GitBackportChecker
-    # @param token [String] token for GitHub authentication
-    # @param days_to_check_from [Integer] the number of days since the pull requests were merged from when we will start the check
-    # @param last_version_number [String] the version number of the last release that we want to make the backport to
-    def initialize(token:, days_to_check_from:, last_version_number:)
-      @token = token
-      @days_to_check_from = days_to_check_from
-      @last_version_number = last_version_number
-    end
-
-    def call
-      pull_requests_with_labels = by_label(
-        label: "type: fix",
-        exclude_labels: ["backport", "no-backport"],
-        days_to_check_from: @days_to_check_from
-      )
-
-      progress_bar = ProgressBar.create(title: "PRs", total: pull_requests_with_labels.count)
-      @report = []
-
-      pull_requests_with_labels.each do |pull_request|
-        progress_bar.increment
-
-        @report << {
-          id: pull_request[:id],
-          title: pull_request[:title],
-          related_issues: related_issues(pull_request[:id])
-        }
+module Decidim
+  module MaintainersToolbox
+    # Extracts the status of the Pull Requests on the decidim repository
+    # with the label "type: fix" and shows the status of the related Pull Requests,
+    # so we can check which PRs have pending backports
+    class GitBackportChecker
+      # @param token [String] token for GitHub authentication
+      # @param days_to_check_from [Integer] the number of days since the pull requests were merged from when we will start the check
+      # @param last_version_number [String] the version number of the last release that we want to make the backport to
+      def initialize(token:, days_to_check_from:, last_version_number:)
+        @token = token
+        @days_to_check_from = days_to_check_from
+        @last_version_number = last_version_number
       end
-    end
 
-    def csv_report
-      Decidim::MaintainersToolbox::BackportsReporter::CSVReport.new(
-        report: @report,
-        last_version_number: @last_version_number
-      ).call
-    end
+      def call
+        pull_requests_with_labels = by_label(
+          label: "type: fix",
+          exclude_labels: ["backport", "no-backport"],
+          days_to_check_from: @days_to_check_from
+        )
 
-    def cli_report
-      Decidim::MaintainersToolbox::BackportsReporter::CLIReport.new(
-        report: @report,
-        last_version_number: @last_version_number
-      ).call
-    end
+        progress_bar = ProgressBar.create(title: "PRs", total: pull_requests_with_labels.count)
+        @report = []
 
-    private
+        pull_requests_with_labels.each do |pull_request|
+          progress_bar.increment
 
-    attr_reader :token
+          @report << {
+            id: pull_request[:id],
+            title: pull_request[:title],
+            related_issues: related_issues(pull_request[:id])
+          }
+        end
+      end
 
-    def by_label(label:, exclude_labels:, days_to_check_from:)
-      Decidim::MaintainersToolbox::GithubManager::Querier::ByLabel.new(
-        token: token,
-        label: label,
-        exclude_labels: exclude_labels,
-        days_to_check_from: days_to_check_from
-      ).call
-    end
+      def csv_report
+        Decidim::MaintainersToolbox::BackportsReporter::CSVReport.new(
+          report: @report,
+          last_version_number: @last_version_number
+        ).call
+      end
 
-    def related_issues(issue_id)
-      Decidim::MaintainersToolbox::GithubManager::Querier::RelatedIssues.new(
-        token: token,
-        issue_id: issue_id
-      ).call
+      def cli_report
+        Decidim::MaintainersToolbox::BackportsReporter::CLIReport.new(
+          report: @report,
+          last_version_number: @last_version_number
+        ).call
+      end
+
+      private
+
+      attr_reader :token
+
+      def by_label(label:, exclude_labels:, days_to_check_from:)
+        Decidim::MaintainersToolbox::GithubManager::Querier::ByLabel.new(
+          token: token,
+          label: label,
+          exclude_labels: exclude_labels,
+          days_to_check_from: days_to_check_from
+        ).call
+      end
+
+      def related_issues(issue_id)
+        Decidim::MaintainersToolbox::GithubManager::Querier::RelatedIssues.new(
+          token: token,
+          issue_id: issue_id
+        ).call
+      end
     end
   end
 end

--- a/lib/decidim/maintainers_toolbox/git_backport_manager.rb
+++ b/lib/decidim/maintainers_toolbox/git_backport_manager.rb
@@ -3,179 +3,182 @@
 require "shellwords"
 require "English"
 
-module Decidim::MaintainersToolbox
-  # Handles the backport of a given pull request to a branch
-  # Uses the git commnad line client
-  # rubocop:disable Rails/Output
-  class GitBackportManager
-    # @param pull_request_id [String] the ID of the pull request that we want to backport
-    # @param release_branch [String] the name of the branch that we want to backport to
-    # @param backport_branch [String] the name of the branch that we want to create
-    # @param working_dir [String] current working directory. Useful for testing purposes
-    # @param exit_with_unstaged_changes [Boolean] wheter we should exit cowardly if there is any unstaged change
-    def initialize(pull_request_id:, release_branch:, backport_branch:, working_dir: Dir.pwd, exit_with_unstaged_changes: false)
-      @pull_request_id = pull_request_id
-      @release_branch = release_branch
-      @backport_branch = sanitize_branch(backport_branch)
-      @working_dir = working_dir
-      @exit_with_unstaged_changes = exit_with_unstaged_changes
-    end
+module Decidim
+  module MaintainersToolbox
+    # Handles the backport of a given pull request to a branch
+    # Uses the git commnad line client
+    # rubocop:disable Rails/Output
+    class GitBackportManager
+      # @param pull_request_id [String] the ID of the pull request that we want to backport
+      # @param release_branch [String] the name of the branch that we want to backport to
+      # @param backport_branch [String] the name of the branch that we want to create
+      # @param working_dir [String] current working directory. Useful for testing purposes
+      # @param exit_with_unstaged_changes [Boolean] wheter we should exit cowardly if there is any unstaged change
+      def initialize(pull_request_id:, release_branch:, backport_branch:, working_dir: Dir.pwd, exit_with_unstaged_changes: false)
+        @pull_request_id = pull_request_id
+        @release_branch = release_branch
+        @backport_branch = sanitize_branch(backport_branch)
+        @working_dir = working_dir
+        @exit_with_unstaged_changes = exit_with_unstaged_changes
+      end
 
-    # Handles all the different tasks involved on a backport with the git command line utility
-    # It does the following tasks:
-    # * Creates a branch based on a release branch
-    # * Apply a commit to this branch
-    # * Push it to the remote repository
-    #
-    # @return [void]
-    def call
-      Dir.chdir(working_dir) do
-        exit_if_unstaged_changes if @exit_with_unstaged_changes
-        self.class.checkout_develop
-        sha_commit = sha_commit_to_backport
+      # Handles all the different tasks involved on a backport with the git command line utility
+      # It does the following tasks:
+      # * Creates a branch based on a release branch
+      # * Apply a commit to this branch
+      # * Push it to the remote repository
+      #
+      # @return [void]
+      def call
+        Dir.chdir(working_dir) do
+          exit_if_unstaged_changes if @exit_with_unstaged_changes
+          self.class.checkout_develop
+          sha_commit = sha_commit_to_backport
 
-        error_message = <<-EOERROR
+          error_message = <<-EOERROR
         Could not find commit for pull request #{pull_request_id}.
         Please make sure you have pulled the latest changes.
-        EOERROR
-        exit_with_errors(error_message) unless sha_commit
+          EOERROR
+          exit_with_errors(error_message) unless sha_commit
 
-        create_backport_branch!
-        cherrypick_commit!(sha_commit)
-        clean_commit_message!
-        push_backport_branch!
+          create_backport_branch!
+          cherrypick_commit!(sha_commit)
+          clean_commit_message!
+          push_backport_branch!
+        end
       end
-    end
 
-    # Switch to the develop branch
-    # In case that it cannot do that, exits
-    #
-    # @return [void]
-    def self.checkout_develop
-      `git checkout develop`
-
-      error_message = <<-EOERROR
-      Could not checkout the develop branch.
-      Please make sure you do not have any uncommitted changes in the current branch.
-      EOERROR
-      exit_with_errors(error_message) unless $CHILD_STATUS.exitstatus.zero?
-    end
-
-    private
-
-    attr_reader :pull_request_id, :release_branch, :backport_branch, :working_dir
-
-    # Create the backport branch based on a release branch
-    # Checks that this branch does not exist already, if it does then exits
-    #
-    # @return [void]
-    def create_backport_branch!
-      `git checkout #{release_branch}`
-
-      diff_count = `git rev-list HEAD..#{remote}/#{release_branch} --count`.strip.to_i
-      `git pull #{remote} #{release_branch}` if diff_count.positive?
-      `git checkout -b #{backport_branch}`
-
-      error_message = <<-EOERROR
-      Branch already exists locally.
-      Delete it with 'git branch -D #{backport_branch}' and rerun the script.
-      EOERROR
-      exit_with_errors(error_message) unless $CHILD_STATUS.exitstatus.zero?
-    end
-
-    # Cherrypick a commit from another branch
-    # Apply the changes introduced by some existing commits
-    # Drops to a shell in case that it needs a manual conflict resolution
-    #
-    # @return [void]
-    def cherrypick_commit!(sha_commit)
-      return unless sha_commit
-
-      puts "Cherrypicking commit #{sha_commit}"
-      `git cherry-pick #{sha_commit}`
-
-      unless $CHILD_STATUS.exitstatus.zero?
-        puts "Resolve the cherrypick conflict manually and exit your shell to keep with the process."
-        system ENV.fetch("SHELL")
-      end
-    end
-
-    # Clean the commit message to remove the pull request ID of the last commit
-    # This is mostly cosmetic, but if we don´t do this, we will have the two IDs on the final commit:
-    # the ID of the original PR and the id of the backported PR.
-    #
-    # @return [void]
-    def clean_commit_message!
-      message = `git log --pretty=format:"%B" -1`
-      message = message.lines[0].gsub!(/ \(#[0-9]+\)$/, "").concat(*message.lines[1..-1])
-      message.gsub!('"', '"\""') # Escape the double quotes for bash as they are the message delimiters
-
-      `git commit --amend -m "#{message}"`
-    end
-
-    # Push the branch to a git remote repository
-    # Checks that there is actually something to push first, if not then it exits.
-    #
-    # @return [void]
-    def push_backport_branch!
-      if `git diff #{backport_branch}..#{release_branch}`.empty?
-        self.class.checkout_develop
+      # Switch to the develop branch
+      # In case that it cannot do that, exits
+      #
+      # @return [void]
+      def self.checkout_develop
+        `git checkout develop`
 
         error_message = <<-EOERROR
+      Could not checkout the develop branch.
+      Please make sure you do not have any uncommitted changes in the current branch.
+        EOERROR
+        exit_with_errors(error_message) unless $CHILD_STATUS.exitstatus.zero?
+      end
+
+      private
+
+      attr_reader :pull_request_id, :release_branch, :backport_branch, :working_dir
+
+      # Create the backport branch based on a release branch
+      # Checks that this branch does not exist already, if it does then exits
+      #
+      # @return [void]
+      def create_backport_branch!
+        `git checkout #{release_branch}`
+
+        diff_count = `git rev-list HEAD..#{remote}/#{release_branch} --count`.strip.to_i
+        `git pull #{remote} #{release_branch}` if diff_count.positive?
+        `git checkout -b #{backport_branch}`
+
+        error_message = <<-EOERROR
+      Branch already exists locally.
+      Delete it with 'git branch -D #{backport_branch}' and rerun the script.
+        EOERROR
+        exit_with_errors(error_message) unless $CHILD_STATUS.exitstatus.zero?
+      end
+
+      # Cherrypick a commit from another branch
+      # Apply the changes introduced by some existing commits
+      # Drops to a shell in case that it needs a manual conflict resolution
+      #
+      # @return [void]
+      def cherrypick_commit!(sha_commit)
+        return unless sha_commit
+
+        puts "Cherrypicking commit #{sha_commit}"
+        `git cherry-pick #{sha_commit}`
+
+        unless $CHILD_STATUS.exitstatus.zero?
+          puts "Resolve the cherrypick conflict manually and exit your shell to keep with the process."
+          system ENV.fetch("SHELL")
+        end
+      end
+
+      # Clean the commit message to remove the pull request ID of the last commit
+      # This is mostly cosmetic, but if we don´t do this, we will have the two IDs on the final commit:
+      # the ID of the original PR and the id of the backported PR.
+      #
+      # @return [void]
+      def clean_commit_message!
+        message = `git log --pretty=format:"%B" -1`
+        message = message.lines[0].gsub!(/ \(#[0-9]+\)$/, "").concat(*message.lines[1..-1])
+        message.gsub!('"', '"\""') # Escape the double quotes for bash as they are the message delimiters
+
+        `git commit --amend -m "#{message}"`
+      end
+
+      # Push the branch to a git remote repository
+      # Checks that there is actually something to push first, if not then it exits.
+      #
+      # @return [void]
+      def push_backport_branch!
+        if `git diff #{backport_branch}..#{release_branch}`.empty?
+          self.class.checkout_develop
+
+          error_message = <<-EOERROR
         Nothing to push to remote server.
         It was probably merged already or the cherry-pick was aborted.
+          EOERROR
+          exit_with_errors(error_message)
+        else
+          puts "Pushing branch #{backport_branch} to #{remote}"
+          `git push #{remote} #{backport_branch}`
+        end
+      end
+
+      # The name of the git remote repository in the local git repository configuration
+      # Most of the times this would be origin or upstream.
+      #
+      # @return [String] the name of the git repository
+      def remote
+        `git remote -v | grep -e 'decidim/decidim\\([^ ]*\\) (push)' | sed 's/\\s.*//'`.strip
+      end
+
+      # The SHA1 commit to backport
+      # It needs to have a pull_request_id associated in the commit message
+      #
+      # @return [String] the SHA1 commit
+      def sha_commit_to_backport
+        `git log --format=oneline | grep "(##{pull_request_id})"`.split.first
+      end
+
+      # Replace all the characters from the user supplied input that are uncontrolled
+      # and could generate a command line injection
+      #
+      # @return [String] the sanitized branch name
+      def sanitize_branch(branch_name)
+        Shellwords.escape(branch_name.gsub("`", ""))
+      end
+
+      # Exit the script execution if there are any unstaged changes
+      #
+      # @return [void]
+      def exit_if_unstaged_changes
+        return if `git diff`.empty?
+
+        error_message = <<-EOERROR
+      There are changes not staged in your project.
+      Please commit your changes or stash them.
         EOERROR
         exit_with_errors(error_message)
-      else
-        puts "Pushing branch #{backport_branch} to #{remote}"
-        `git push #{remote} #{backport_branch}`
+      end
+
+      # Exit the script execution with a message
+      #
+      # @return [void]
+      def exit_with_errors(message)
+        puts message
+        exit 1
       end
     end
 
-    # The name of the git remote repository in the local git repository configuration
-    # Most of the times this would be origin or upstream.
-    #
-    # @return [String] the name of the git repository
-    def remote
-      `git remote -v | grep -e 'decidim/decidim\\([^ ]*\\) (push)' | sed 's/\\s.*//'`.strip
-    end
-
-    # The SHA1 commit to backport
-    # It needs to have a pull_request_id associated in the commit message
-    #
-    # @return [String] the SHA1 commit
-    def sha_commit_to_backport
-      `git log --format=oneline | grep "(##{pull_request_id})"`.split.first
-    end
-
-    # Replace all the characters from the user supplied input that are uncontrolled
-    # and could generate a command line injection
-    #
-    # @return [String] the sanitized branch name
-    def sanitize_branch(branch_name)
-      Shellwords.escape(branch_name.gsub("`", ""))
-    end
-
-    # Exit the script execution if there are any unstaged changes
-    #
-    # @return [void]
-    def exit_if_unstaged_changes
-      return if `git diff`.empty?
-
-      error_message = <<-EOERROR
-      There are changes not staged in your project.
-      Please commit your changes or stash them.
-      EOERROR
-      exit_with_errors(error_message)
-    end
-
-    # Exit the script execution with a message
-    #
-    # @return [void]
-    def exit_with_errors(message)
-      puts message
-      exit 1
-    end
+    # rubocop:enable Rails/Output
   end
-  # rubocop:enable Rails/Output
 end

--- a/lib/decidim/maintainers_toolbox/github_manager/poster.rb
+++ b/lib/decidim/maintainers_toolbox/github_manager/poster.rb
@@ -4,69 +4,72 @@ require "active_support/core_ext/hash/except"
 require "faraday"
 require "json"
 
-module Decidim::MaintainersToolbox
-  module GithubManager
-    # Allows to make POST requests to GitHub Rest API about Pull Requests
-    # @see https://docs.github.com/en/rest
-    # rubocop:disable Rails/Output
-    class Poster
-      # @param token [String] token for GitHub authentication
-      # @param params [Hash] Parameters accepted by the GitHub API
-      def initialize(token:, params:)
-        @token = token
-        @params = params
-      end
-
-      # Create the pull request or give error messages
-      #
-      # @return [Faraday::Response] An instance that represents an HTTP response from making an HTTP request
-      def call
-        response = create_pull_request!
-        pull_request_id = JSON.parse(response.body)["number"]
-        unless pull_request_id
-          puts "Pull request could not be created!"
-          puts "Please make sure you have enabled the 'public_repo' scope for the access token"
-          return
+module Decidim
+  module MaintainersToolbox
+    module GithubManager
+      # Allows to make POST requests to GitHub Rest API about Pull Requests
+      # @see https://docs.github.com/en/rest
+      # rubocop:disable Rails/Output
+      class Poster
+        # @param token [String] token for GitHub authentication
+        # @param params [Hash] Parameters accepted by the GitHub API
+        def initialize(token:, params:)
+          @token = token
+          @params = params
         end
-        puts "Pull request created at https://github.com/decidim/decidim/pull/#{pull_request_id}"
 
-        add_labels_to_issue!(pull_request_id)
+        # Create the pull request or give error messages
+        #
+        # @return [Faraday::Response] An instance that represents an HTTP response from making an HTTP request
+        def call
+          response = create_pull_request!
+          pull_request_id = JSON.parse(response.body)["number"]
+          unless pull_request_id
+            puts "Pull request could not be created!"
+            puts "Please make sure you have enabled the 'public_repo' scope for the access token"
+            return
+          end
+          puts "Pull request created at https://github.com/decidim/decidim/pull/#{pull_request_id}"
+
+          add_labels_to_issue!(pull_request_id)
+        end
+
+        private
+
+        attr_reader :token, :params
+
+        # Make the POST request to GitHub API of the decidim repository
+        #
+        # @param path [String] The path to do the request to the GitHub API
+        # @param some_params [Hash] The parameters of the request
+        # @return [Faraday::Response] An instance that represents an HTTP response from making an HTTP request
+        def post!(path, some_params)
+          uri = "https://api.github.com/repos/decidim/decidim/#{path}"
+          Faraday.post(uri, some_params.to_json, { Authorization: "token #{token}" })
+        end
+
+        # Create a pull request using the GitHub API
+        #
+        # @see https://docs.github.com/en/rest/pulls/pulls#create-a-pull-request GitHub API documentation
+        # @return [Faraday::Response] An instance that represents an HTTP response from making an HTTP request
+        def create_pull_request!
+          puts "Creating the PR in GitHub"
+          post!("pulls", params.except(:labels))
+        end
+
+        # Add labels to an issue or a pull request
+        # GitHub does not support adding labels while creating the PR, so we need to do it afterwards
+        #
+        # @see https://docs.github.com/en/rest/issues/labels#add-labels-to-an-issue GitHub API documentation
+        # @param issue_id [String] String of the issue to add the labels to
+        # @return [Faraday::Response] An instance that represents an HTTP response from making an HTTP request
+        def add_labels_to_issue!(issue_id)
+          puts "Adding the labels to the PR"
+          post!("issues/#{issue_id}/labels", params.slice(:labels))
+        end
       end
 
-      private
-
-      attr_reader :token, :params
-
-      # Make the POST request to GitHub API of the decidim repository
-      #
-      # @param path [String] The path to do the request to the GitHub API
-      # @param some_params [Hash] The parameters of the request
-      # @return [Faraday::Response] An instance that represents an HTTP response from making an HTTP request
-      def post!(path, some_params)
-        uri = "https://api.github.com/repos/decidim/decidim/#{path}"
-        Faraday.post(uri, some_params.to_json, { Authorization: "token #{token}" })
-      end
-
-      # Create a pull request using the GitHub API
-      #
-      # @see https://docs.github.com/en/rest/pulls/pulls#create-a-pull-request GitHub API documentation
-      # @return [Faraday::Response] An instance that represents an HTTP response from making an HTTP request
-      def create_pull_request!
-        puts "Creating the PR in GitHub"
-        post!("pulls", params.except(:labels))
-      end
-
-      # Add labels to an issue or a pull request
-      # GitHub does not support adding labels while creating the PR, so we need to do it afterwards
-      #
-      # @see https://docs.github.com/en/rest/issues/labels#add-labels-to-an-issue GitHub API documentation
-      # @param issue_id [String] String of the issue to add the labels to
-      # @return [Faraday::Response] An instance that represents an HTTP response from making an HTTP request
-      def add_labels_to_issue!(issue_id)
-        puts "Adding the labels to the PR"
-        post!("issues/#{issue_id}/labels", params.slice(:labels))
-      end
+      # rubocop:enable Rails/Output
     end
-    # rubocop:enable Rails/Output
   end
 end

--- a/lib/decidim/maintainers_toolbox/github_manager/querier.rb
+++ b/lib/decidim/maintainers_toolbox/github_manager/querier.rb
@@ -7,15 +7,17 @@ require_relative "querier/by_issue_id"
 require_relative "querier/by_label"
 require_relative "querier/related_issues"
 
-module Decidim::MaintainersToolbox
-  module GithubManager
-    # Allows to make GET requests to GitHub Rest API about Issues and Pull Requests
-    # @see https://docs.github.com/en/rest
-    module Querier
-      autoload :ByIssueId, "decidim/maintainers_toolbox/github_manager/querier/by_issue_id"
-      autoload :ByLabel, "decidim/maintainers_toolbox/github_manager/querier/by_label"
-      autoload :ByTitle, "decidim/maintainers_toolbox/github_manager/querier/by_title"
-      autoload :RelatedIssues, "decidim/maintainers_toolbox/github_manager/querier/related_issues"
+module Decidim
+  module MaintainersToolbox
+    module GithubManager
+      # Allows to make GET requests to GitHub Rest API about Issues and Pull Requests
+      # @see https://docs.github.com/en/rest
+      module Querier
+        autoload :ByIssueId, "decidim/maintainers_toolbox/github_manager/querier/by_issue_id"
+        autoload :ByLabel, "decidim/maintainers_toolbox/github_manager/querier/by_label"
+        autoload :ByTitle, "decidim/maintainers_toolbox/github_manager/querier/by_title"
+        autoload :RelatedIssues, "decidim/maintainers_toolbox/github_manager/querier/related_issues"
+      end
     end
   end
 end

--- a/lib/decidim/maintainers_toolbox/github_manager/querier/base.rb
+++ b/lib/decidim/maintainers_toolbox/github_manager/querier/base.rb
@@ -4,73 +4,75 @@ require "json"
 require "faraday"
 require "uri"
 
-module Decidim::MaintainersToolbox
-  module GithubManager
-    module Querier
-      # Base class that allows making GET requests to GitHub Rest API about Issues and Pull Requests
-      # This must be inherited from other class with the following methods:
-      # - call
-      # - uri
-      # @see https://docs.github.com/en/rest
-      class Base
-        class InvalidMetadataError < StandardError; end
+module Decidim
+  module MaintainersToolbox
+    module GithubManager
+      module Querier
+        # Base class that allows making GET requests to GitHub Rest API about Issues and Pull Requests
+        # This must be inherited from other class with the following methods:
+        # - call
+        # - uri
+        # @see https://docs.github.com/en/rest
+        class Base
+          class InvalidMetadataError < StandardError; end
 
-        def initialize(token:)
-          @token = token
-        end
-
-        def call
-          raise "Not implemented"
-        end
-
-        private
-
-        attr_reader :token
-
-        def headers
-          nil
-        end
-
-        def authorization_header
-          { Authorization: "token #{token}" }
-        end
-
-        def request(uri)
-          response = Faraday.get(uri, headers, authorization_header)
-
-          { body: response.body, headers: response.headers }
-        end
-
-        # Get's the JSON response from a URI
-        # Supports pagination
-        #
-        # @param uri {String} - The URL that we want to get the JSON response from
-        # @param old_json {Array} - The Array with the old_json or an empty Array if it is the first time that we are calling this method
-        def json_response(uri, old_json = [])
-          body, headers = request(uri).values_at(:body, :headers)
-          json = JSON.parse(body)
-          json.concat(old_json) if json.is_a?(Array)
-          raise InvalidMetadataError if json.is_a?(Hash) && json["message"] == "Bad credentials"
-
-          # If there are more pages, then we call ourselves redundantly to fetch the next page
-          next_json = more_pages?(headers) ? json_response(next_page(headers), json) : []
-
-          if json.is_a?(Array)
-            # For some reason we have duplicated values, so we deduplicate them
-            json.concat(next_json).uniq { |issue| issue.has_key?("number") ? issue["number"] : issue }
-          else
-            json
+          def initialize(token:)
+            @token = token
           end
-        end
 
-        def more_pages?(headers)
-          return false if headers["link"].nil?
+          def call
+            raise "Not implemented"
+          end
 
-          headers["link"].include?('rel="next"')
-        end
+          private
 
-        def next_page(headers)
-          URI.extract(headers["link"].split(",").select { |url| url.end_with?('rel="next"') }[0])[0]
+          attr_reader :token
+
+          def headers
+            nil
+          end
+
+          def authorization_header
+            { Authorization: "token #{token}" }
+          end
+
+          def request(uri)
+            response = Faraday.get(uri, headers, authorization_header)
+
+            { body: response.body, headers: response.headers }
+          end
+
+          # Get's the JSON response from a URI
+          # Supports pagination
+          #
+          # @param uri {String} - The URL that we want to get the JSON response from
+          # @param old_json {Array} - The Array with the old_json or an empty Array if it is the first time that we are calling this method
+          def json_response(uri, old_json = [])
+            body, headers = request(uri).values_at(:body, :headers)
+            json = JSON.parse(body)
+            json.concat(old_json) if json.is_a?(Array)
+            raise InvalidMetadataError if json.is_a?(Hash) && json["message"] == "Bad credentials"
+
+            # If there are more pages, then we call ourselves redundantly to fetch the next page
+            next_json = more_pages?(headers) ? json_response(next_page(headers), json) : []
+
+            if json.is_a?(Array)
+              # For some reason we have duplicated values, so we deduplicate them
+              json.concat(next_json).uniq { |issue| issue.has_key?("number") ? issue["number"] : issue }
+            else
+              json
+            end
+          end
+
+          def more_pages?(headers)
+            return false if headers["link"].nil?
+
+            headers["link"].include?('rel="next"')
+          end
+
+          def next_page(headers)
+            URI.extract(headers["link"].split(",").select { |url| url.end_with?('rel="next"') }[0])[0]
+          end
         end
       end
     end

--- a/lib/decidim/maintainers_toolbox/github_manager/querier/by_issue_id.rb
+++ b/lib/decidim/maintainers_toolbox/github_manager/querier/by_issue_id.rb
@@ -2,43 +2,45 @@
 
 require_relative "base"
 
-module Decidim::MaintainersToolbox
-  module GithubManager
-    module Querier
-      # Makes a GET request for the metadata of an Issue or Pull Request in GitHub
-      #
-      # @see https://docs.github.com/en/rest/issues/issues#get-an-issue GitHub API documentation
-      class ByIssueId < Decidim::MaintainersToolbox::GithubManager::Querier::Base
-        def initialize(issue_id:, token:)
-          @issue_id = issue_id
-          @token = token
-        end
-
-        # Makes the GET request and parses the response of an Issue or Pull Request in GitHub
+module Decidim
+  module MaintainersToolbox
+    module GithubManager
+      module Querier
+        # Makes a GET request for the metadata of an Issue or Pull Request in GitHub
         #
-        # @return [Hash]
-        def call
-          data = json_response("https://api.github.com/repos/decidim/decidim/issues/#{@issue_id}")
-          return unless data["number"]
+        # @see https://docs.github.com/en/rest/issues/issues#get-an-issue GitHub API documentation
+        class ByIssueId < Decidim::MaintainersToolbox::GithubManager::Querier::Base
+          def initialize(issue_id:, token:)
+            @issue_id = issue_id
+            @token = token
+          end
 
-          parse(data)
-        end
+          # Makes the GET request and parses the response of an Issue or Pull Request in GitHub
+          #
+          # @return [Hash]
+          def call
+            data = json_response("https://api.github.com/repos/decidim/decidim/issues/#{@issue_id}")
+            return unless data["number"]
 
-        private
+            parse(data)
+          end
 
-        # Parses the response of an Issue or Pull Request in GitHub
-        #
-        # @return [Hash]
-        def parse(metadata)
-          labels = metadata["labels"].map { |l| l["name"] }.sort
+          private
 
-          {
-            id: metadata["number"],
-            title: metadata["title"],
-            labels: labels,
-            type: labels.select { |l| l.match(/^type: /) || l == "target: developer-experience" },
-            modules: labels.select { |l| l.match(/^module: /) }
-          }
+          # Parses the response of an Issue or Pull Request in GitHub
+          #
+          # @return [Hash]
+          def parse(metadata)
+            labels = metadata["labels"].map { |l| l["name"] }.sort
+
+            {
+              id: metadata["number"],
+              title: metadata["title"],
+              labels: labels,
+              type: labels.select { |l| l.match(/^type: /) || l == "target: developer-experience" },
+              modules: labels.select { |l| l.match(/^module: /) }
+            }
+          end
         end
       end
     end

--- a/lib/decidim/maintainers_toolbox/github_manager/querier/by_label.rb
+++ b/lib/decidim/maintainers_toolbox/github_manager/querier/by_label.rb
@@ -3,91 +3,93 @@
 require "active_support/core_ext/time/zones"
 require_relative "base"
 
-module Decidim::MaintainersToolbox
-  module GithubManager
-    module Querier
-      # Makes a GET request for the list of Issues or Pull Requests in GitHub.
-      # They must comply the following conditions:
-      # * To be merged in the period between the days to check from and today. (90 days by default)
-      # * To have the label that we are querying ("type: fix" by default)
-      # * To not have any of the excluded labels (["backport", "no-backport"] by default)
-      # * To have been merged
-      #
-      # @param token [String] token for GitHub authentication
-      # @param days_to_check_from [Integer] the number of days since the pull requests were merged from when we will start the check
-      # @param label [String] the label that we want to search by
-      # @param exclude_labels [Array] the labels that we want to exclude in the search
-      #
-      # @see https://docs.github.com/en/rest/issues/issues#list-repository-issues GitHub API documentation
-      class ByLabel < Decidim::MaintainersToolbox::GithubManager::Querier::Base
-        def initialize(token:, days_to_check_from: 90, label: "type: fix", exclude_labels: ["backport", "no-backport"])
-          @label = label
-          @exclude_labels = exclude_labels
-          @token = token
-          @days_to_check_from = days_to_check_from
-        end
-
-        # Makes the GET request and parses the response of an Issue or Pull Request in GitHub
+module Decidim
+  module MaintainersToolbox
+    module GithubManager
+      module Querier
+        # Makes a GET request for the list of Issues or Pull Requests in GitHub.
+        # They must comply the following conditions:
+        # * To be merged in the period between the days to check from and today. (90 days by default)
+        # * To have the label that we are querying ("type: fix" by default)
+        # * To not have any of the excluded labels (["backport", "no-backport"] by default)
+        # * To have been merged
         #
-        # @return [Hash]
-        def call
-          parse json_response("https://api.github.com/repos/decidim/decidim/issues")
-        end
-
-        private
-
-        attr_reader :label, :exclude_labels, :days_to_check_from
-
-        def headers
-          Time.zone = "UTC"
-
-          {
-            labels: label,
-            state: "closed",
-            per_page: 100,
-            since: since.iso8601
-          }
-        end
-
-        def since
-          Time.zone.today - days_to_check_from
-        end
-
-        # Parses the response of an Issue or Pull Request in GitHub
+        # @param token [String] token for GitHub authentication
+        # @param days_to_check_from [Integer] the number of days since the pull requests were merged from when we will start the check
+        # @param label [String] the label that we want to search by
+        # @param exclude_labels [Array] the labels that we want to exclude in the search
         #
-        # @return [Hash]
-        def parse(metadata)
-          metadata.map do |item|
-            next if has_any_of_excluded_labels?(item)
-            next unless merged?(item)
-            next unless merged_in_date_range?(item)
+        # @see https://docs.github.com/en/rest/issues/issues#list-repository-issues GitHub API documentation
+        class ByLabel < Decidim::MaintainersToolbox::GithubManager::Querier::Base
+          def initialize(token:, days_to_check_from: 90, label: "type: fix", exclude_labels: ["backport", "no-backport"])
+            @label = label
+            @exclude_labels = exclude_labels
+            @token = token
+            @days_to_check_from = days_to_check_from
+          end
+
+          # Makes the GET request and parses the response of an Issue or Pull Request in GitHub
+          #
+          # @return [Hash]
+          def call
+            parse json_response("https://api.github.com/repos/decidim/decidim/issues")
+          end
+
+          private
+
+          attr_reader :label, :exclude_labels, :days_to_check_from
+
+          def headers
+            Time.zone = "UTC"
 
             {
-              id: item["number"],
-              title: item["title"]
+              labels: label,
+              state: "closed",
+              per_page: 100,
+              since: since.iso8601
             }
-          end.compact
-        end
+          end
 
-        def has_any_of_excluded_labels?(item)
-          item["labels"].map { |label| label.map { |_key, val| exclude_labels.include?(val) } }.flatten.any? true
-        end
+          def since
+            Time.zone.today - days_to_check_from
+          end
 
-        def merged_at(item)
-          Date.parse(item["pull_request"]["merged_at"])
-        end
+          # Parses the response of an Issue or Pull Request in GitHub
+          #
+          # @return [Hash]
+          def parse(metadata)
+            metadata.map do |item|
+              next if has_any_of_excluded_labels?(item)
+              next unless merged?(item)
+              next unless merged_in_date_range?(item)
 
-        def merged?(item)
-          return false if item["pull_request"].nil?
-          return false if item["pull_request"]["merged_at"].nil?
+              {
+                id: item["number"],
+                title: item["title"]
+              }
+            end.compact
+          end
 
-          merged_at(item).present?
-        rescue TypeError, Date::Error
-          false
-        end
+          def has_any_of_excluded_labels?(item)
+            item["labels"].map { |label| label.map { |_key, val| exclude_labels.include?(val) } }.flatten.any? true
+          end
 
-        def merged_in_date_range?(item)
-          merged_at(item) > since
+          def merged_at(item)
+            Date.parse(item["pull_request"]["merged_at"])
+          end
+
+          def merged?(item)
+            return false if item["pull_request"].nil?
+            return false if item["pull_request"]["merged_at"].nil?
+
+            merged_at(item).present?
+          rescue TypeError, Date::Error
+            false
+          end
+
+          def merged_in_date_range?(item)
+            merged_at(item) > since
+          end
         end
       end
     end

--- a/lib/decidim/maintainers_toolbox/github_manager/querier/by_title.rb
+++ b/lib/decidim/maintainers_toolbox/github_manager/querier/by_title.rb
@@ -2,53 +2,55 @@
 
 require_relative "base"
 
-module Decidim::MaintainersToolbox
-  module GithubManager
-    module Querier
-      # Makes a GET request for the list of Issues or Pull Requests in GitHub.
-      #
-      # @param token [String] token for GitHub authentication
-      # @param title [String] the title that we want to search by
-      # @param state [String] the state of the issue. By default is "open"
-      #
-      # @see https://docs.github.com/en/rest/issues/issues#list-repository-issues GitHub API documentation
-      class ByTitle < Decidim::MaintainersToolbox::GithubManager::Querier::Base
-        def initialize(title:, token:, state: "open")
-          @title = title
-          @token = token
-          @state = state
-        end
-
-        # Makes the GET request and parses the response of an Issue or Pull Request in GitHub
+module Decidim
+  module MaintainersToolbox
+    module GithubManager
+      module Querier
+        # Makes a GET request for the list of Issues or Pull Requests in GitHub.
         #
-        # @return [Hash]
-        def call
-          data = json_response("https://api.github.com/repos/decidim/decidim/issues")
-
-          parse(data)
-        end
-
-        private
-
-        attr_reader :title, :state
-
-        def headers
-          {
-            title: title,
-            state: state,
-            per_page: 100
-          }
-        end
-
-        # Parses the response of an Issue or Pull Request in GitHub
+        # @param token [String] token for GitHub authentication
+        # @param title [String] the title that we want to search by
+        # @param state [String] the state of the issue. By default is "open"
         #
-        # @return [Hash]
-        def parse(metadata)
-          metadata.map do |item|
+        # @see https://docs.github.com/en/rest/issues/issues#list-repository-issues GitHub API documentation
+        class ByTitle < Decidim::MaintainersToolbox::GithubManager::Querier::Base
+          def initialize(title:, token:, state: "open")
+            @title = title
+            @token = token
+            @state = state
+          end
+
+          # Makes the GET request and parses the response of an Issue or Pull Request in GitHub
+          #
+          # @return [Hash]
+          def call
+            data = json_response("https://api.github.com/repos/decidim/decidim/issues")
+
+            parse(data)
+          end
+
+          private
+
+          attr_reader :title, :state
+
+          def headers
             {
-              id: item["number"],
-              title: item["title"]
+              title: title,
+              state: state,
+              per_page: 100
             }
+          end
+
+          # Parses the response of an Issue or Pull Request in GitHub
+          #
+          # @return [Hash]
+          def parse(metadata)
+            metadata.map do |item|
+              {
+                id: item["number"],
+                title: item["title"]
+              }
+            end
           end
         end
       end

--- a/lib/decidim/maintainers_toolbox/github_manager/querier/related_issues.rb
+++ b/lib/decidim/maintainers_toolbox/github_manager/querier/related_issues.rb
@@ -2,47 +2,49 @@
 
 require_relative "base"
 
-module Decidim::MaintainersToolbox
-  module GithubManager
-    module Querier
-      # Makes a GET request for the related issues of an Issue or Pull Request in GitHub
-      # Uses the Timeline events API endpoint
-      #
-      # @see https://docs.github.com/en/rest/issues/timeline?apiVersion=2022-11-28 GitHub API documentation
-      class RelatedIssues < Decidim::MaintainersToolbox::GithubManager::Querier::Base
-        def initialize(issue_id:, token:)
-          @issue_id = issue_id
-          @token = token
-        end
-
-        # Makes the GET request and parses the response of an Issue or Pull Request in GitHub
+module Decidim
+  module MaintainersToolbox
+    module GithubManager
+      module Querier
+        # Makes a GET request for the related issues of an Issue or Pull Request in GitHub
+        # Uses the Timeline events API endpoint
         #
-        # @return [Hash]
-        def call
-          parse(json_response("https://api.github.com/repos/decidim/decidim/issues/#{@issue_id}/timeline"))
-        end
-
-        private
-
-        def headers
-          { per_page: 100 }
-        end
-
-        # Parses the response of an Issue or Pull Request in GitHub
-        #
-        # @return [Hash]
-        def parse(metadata)
-          references = metadata.select do |item|
-            item["event"] == "cross-referenced" && item["source"]["issue"]["repository"]["full_name"] == "decidim/decidim"
+        # @see https://docs.github.com/en/rest/issues/timeline?apiVersion=2022-11-28 GitHub API documentation
+        class RelatedIssues < Decidim::MaintainersToolbox::GithubManager::Querier::Base
+          def initialize(issue_id:, token:)
+            @issue_id = issue_id
+            @token = token
           end
-          references.map do |item|
-            issue = item["source"]["issue"]
 
-            {
-              id: issue["number"],
-              title: issue["title"].strip,
-              state: issue.dig("pull_request", "merged_at").nil? ? issue["state"] : "merged"
-            }
+          # Makes the GET request and parses the response of an Issue or Pull Request in GitHub
+          #
+          # @return [Hash]
+          def call
+            parse(json_response("https://api.github.com/repos/decidim/decidim/issues/#{@issue_id}/timeline"))
+          end
+
+          private
+
+          def headers
+            { per_page: 100 }
+          end
+
+          # Parses the response of an Issue or Pull Request in GitHub
+          #
+          # @return [Hash]
+          def parse(metadata)
+            references = metadata.select do |item|
+              item["event"] == "cross-referenced" && item["source"]["issue"]["repository"]["full_name"] == "decidim/decidim"
+            end
+            references.map do |item|
+              issue = item["source"]["issue"]
+
+              {
+                id: issue["number"],
+                title: issue["title"].strip,
+                state: issue.dig("pull_request", "merged_at").nil? ? issue["state"] : "merged"
+              }
+            end
           end
         end
       end

--- a/lib/decidim/maintainers_toolbox/releaser.rb
+++ b/lib/decidim/maintainers_toolbox/releaser.rb
@@ -5,208 +5,209 @@ require_relative "github_manager/poster"
 require_relative "github_manager/querier/by_title"
 require_relative "changelog_generator"
 
-module Decidim::MaintainersToolbox
-  class Releaser
-    class InvalidMetadataError < StandardError; end
+module Decidim
+  module MaintainersToolbox
+    class Releaser
+      class InvalidMetadataError < StandardError; end
 
-    class InvalidBranchError < StandardError; end
+      class InvalidBranchError < StandardError; end
 
-    class InvalidVersionTypeError < StandardError; end
+      class InvalidVersionTypeError < StandardError; end
 
-    DECIDIM_VERSION_FILE = ".decidim-version"
+      DECIDIM_VERSION_FILE = ".decidim-version"
 
-    # @param token [String] token for GitHub authentication
-    # @param version_type [String] The kind of release that you want to prepare. Supported values: rc, minor, patch
-    # @param working_dir [String] current working directory. Useful for testing purposes
-    # @param exit_with_unstaged_changes [Boolean] wheter we should exit cowardly if there is any unstaged change
-    def initialize(token:, version_type:, working_dir: Dir.pwd, exit_with_unstaged_changes: false)
-      @token = token
-      @version_type = version_type
-      @working_dir = working_dir
-      @exit_with_unstaged_changes = exit_with_unstaged_changes
-    end
-
-    def call
-      Dir.chdir(@working_dir) do
-        exit_if_unstaged_changes if @exit_with_unstaged_changes
-        exit_if_pending_crowdin_pull_request
-
-        puts "Starting the release process for #{version_number} in 10 seconds"
-        sleep 10
-
-        run("git checkout #{release_branch}")
-        run("git pull origin #{release_branch}")
-        bump_decidim_version
-        run("bin/rake update_versions")
-        run("bin/rake patch_generators")
-        run("bin/rake bundle")
-        run("npm install")
-
-        check_tests
-
-        generate_changelog
-
-        run("git checkout -b chore/prepare/#{version_number}")
-        run("git commit -a -m 'Prepare #{version_number} release'")
-        run("git push origin chore/prepare/#{version_number}")
-
-        create_pull_request
+      # @param token [String] token for GitHub authentication
+      # @param version_type [String] The kind of release that you want to prepare. Supported values: rc, minor, patch
+      # @param working_dir [String] current working directory. Useful for testing purposes
+      # @param exit_with_unstaged_changes [Boolean] wheter we should exit cowardly if there is any unstaged change
+      def initialize(token:, version_type:, working_dir: Dir.pwd, exit_with_unstaged_changes: false)
+        @token = token
+        @version_type = version_type
+        @working_dir = working_dir
+        @exit_with_unstaged_changes = exit_with_unstaged_changes
       end
-    end
 
-    private
+      def call
+        Dir.chdir(@working_dir) do
+          exit_if_unstaged_changes if @exit_with_unstaged_changes
+          exit_if_pending_crowdin_pull_request
 
-    # The git branch
-    #
-    # @return [String]
-    def branch
-      @branch ||= capture("git rev-parse --abbrev-ref HEAD")[0].strip
-    end
+          puts "Starting the release process for #{version_number} in 10 seconds"
+          sleep 10
 
-    # Raise an error if the branch does not start with the preffix "release/"
-    # or returns the branch name
-    #
-    # @raise [InvalidBranchError]
-    #
-    # @return [String]
-    def release_branch
-      raise InvalidBranchError, "This is not a release branch, aborting" unless branch.start_with?("release/")
+          run("git checkout #{release_branch}")
+          run("git pull origin #{release_branch}")
+          bump_decidim_version
+          run("bin/rake update_versions")
+          run("bin/rake patch_generators")
+          run("bin/rake bundle")
+          run("npm install")
 
-      branch
-    end
+          check_tests
 
-    # Changes the decidim version in the file
-    #
-    # @return [void]
-    def bump_decidim_version
-      File.write(DECIDIM_VERSION_FILE, version_number)
-    end
+          generate_changelog
 
-    # The version number for the release that we are preparing
-    #
-    # @todo support the "minor" type version
-    #
-    # @return [String] the version number
-    def version_number
-      @version_number ||= case @version_type
-                          when "rc"
-                            next_version_number_for_release_candidate(old_version_number)
-                          when "patch"
-                            next_version_number_for_patch_release(old_version_number)
-                          else
-                            raise InvalidVersionTypeError, "This is not a supported version type"
-                          end
-    end
+          run("git checkout -b chore/prepare/#{version_number}")
+          run("git commit -a -m 'Prepare #{version_number} release'")
+          run("git push origin chore/prepare/#{version_number}")
 
-    def parsed_version_number(version_number)
-      /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)/ =~ version_number
+          create_pull_request
+        end
+      end
 
-      [major.to_i, minor.to_i, patch.to_i]
-    end
+      private
 
-    # Given a version number, returns the next release candidate
-    #
-    # If the current version number is `dev`, then we return the `rc1` version
-    # If the current version number is `rc`, then we return the next `rc` version
-    # Else, it means is a `minor` or `patch` version. On those cases we raise an Exception, as releases candidates should
-    # be only done from a `dev` or a `rc` version.
-    #
-    # @raise [InvalidVersionTypeError]
-    #
-    # @param current_version_number [String] - The version number of the current version
-    #
-    # @return [String] - the new version number
-    def next_version_number_for_release_candidate(current_version_number)
-      if current_version_number.include? "dev"
-        major, minor, patch = parsed_version_number(current_version_number)
-        new_version_number = "#{major}.#{minor}.#{patch}.rc1"
-      elsif current_version_number.include? "rc"
-        new_rc_number = current_version_number.match(/rc(\d)/)[1].to_i + 1
-        new_version_number = current_version_number.gsub(/rc\d/, "rc#{new_rc_number}")
-      else
-        error_message = <<-EOMESSAGE
+      # The git branch
+      #
+      # @return [String]
+      def branch
+        @branch ||= capture("git rev-parse --abbrev-ref HEAD")[0].strip
+      end
+
+      # Raise an error if the branch does not start with the preffix "release/"
+      # or returns the branch name
+      #
+      # @raise [InvalidBranchError]
+      #
+      # @return [String]
+      def release_branch
+        raise InvalidBranchError, "This is not a release branch, aborting" unless branch.start_with?("release/")
+
+        branch
+      end
+
+      # Changes the decidim version in the file
+      #
+      # @return [void]
+      def bump_decidim_version
+        File.write(DECIDIM_VERSION_FILE, version_number)
+      end
+
+      # The version number for the release that we are preparing
+      #
+      # @todo support the "minor" type version
+      #
+      # @return [String] the version number
+      def version_number
+        @version_number ||= case @version_type
+                            when "rc"
+                              next_version_number_for_release_candidate(old_version_number)
+                            when "patch"
+                              next_version_number_for_patch_release(old_version_number)
+                            else
+                              raise InvalidVersionTypeError, "This is not a supported version type"
+                            end
+      end
+
+      def parsed_version_number(version_number)
+        /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)/ =~ version_number
+
+        [major.to_i, minor.to_i, patch.to_i]
+      end
+
+      # Given a version number, returns the next release candidate
+      #
+      # If the current version number is `dev`, then we return the `rc1` version
+      # If the current version number is `rc`, then we return the next `rc` version
+      # Else, it means is a `minor` or `patch` version. On those cases we raise an Exception, as releases candidates should
+      # be only done from a `dev` or a `rc` version.
+      #
+      # @raise [InvalidVersionTypeError]
+      #
+      # @param current_version_number [String] - The version number of the current version
+      #
+      # @return [String] - the new version number
+      def next_version_number_for_release_candidate(current_version_number)
+        if current_version_number.include? "dev"
+          major, minor, patch = parsed_version_number(current_version_number)
+          new_version_number = "#{major}.#{minor}.#{patch}.rc1"
+        elsif current_version_number.include? "rc"
+          new_rc_number = current_version_number.match(/rc(\d)/)[1].to_i + 1
+          new_version_number = current_version_number.gsub(/rc\d/, "rc#{new_rc_number}")
+        else
+          error_message = <<-EOMESSAGE
           Trying to do a release candidate version from patch release. Bailing out.
           You need to do a release candidate from a `dev` or from another `rc` version
-        EOMESSAGE
-        raise InvalidVersionTypeError, error_message
+          EOMESSAGE
+          raise InvalidVersionTypeError, error_message
+        end
+
+        new_version_number
       end
 
-      new_version_number
-    end
+      # Given a version number, returns the next patch release
+      #
+      # If the current version number is `dev`, then we raise an Exception, as you need to first do a release candidate.
+      # If the current version number is `rc`, then we return the `0` patch version
+      # Else, it means is a `patch` version, so we return the next patch version
+      #
+      # @raise [InvalidVersionTypeError]
+      #
+      # @param current_version_number [String] - The version number of the current version
+      #
+      # @return [String] - the new version number
+      def next_version_number_for_patch_release(current_version_number)
+        major, minor, patch = parsed_version_number(current_version_number)
 
-    # Given a version number, returns the next patch release
-    #
-    # If the current version number is `dev`, then we raise an Exception, as you need to first do a release candidate.
-    # If the current version number is `rc`, then we return the `0` patch version
-    # Else, it means is a `patch` version, so we return the next patch version
-    #
-    # @raise [InvalidVersionTypeError]
-    #
-    # @param current_version_number [String] - The version number of the current version
-    #
-    # @return [String] - the new version number
-    def next_version_number_for_patch_release(current_version_number)
-      major, minor, patch = parsed_version_number(current_version_number)
-
-      if current_version_number.include? "dev"
-        error_message = <<-EOMESSAGE
+        if current_version_number.include? "dev"
+          error_message = <<-EOMESSAGE
           Trying to do a patch version from dev release. Bailing out.
           You need to do first a release candidate.
-        EOMESSAGE
-        raise InvalidVersionTypeError, error_message
-      elsif current_version_number.include? "rc"
-        new_version_number = "#{major}.#{minor}.0"
-      else
-        new_version_number = "#{major}.#{minor}.#{patch.to_i + 1}"
+          EOMESSAGE
+          raise InvalidVersionTypeError, error_message
+        elsif current_version_number.include? "rc"
+          new_version_number = "#{major}.#{minor}.0"
+        else
+          new_version_number = "#{major}.#{minor}.#{patch.to_i + 1}"
+        end
+
+        new_version_number
       end
 
-      new_version_number
-    end
-
-    # The version number from the file
-    #
-    # @return [String] the version number
-    def old_version_number
-      File.read(DECIDIM_VERSION_FILE).strip
-    end
-
-    # Run the tests and if fails restore the changes using git and exit with an error
-    #
-    # @return [void]
-    def check_tests
-      puts "Running specs"
-      output, status = capture("bin/rspec")
-
-      unless status.success?
-        run("git restore .")
-        puts output
-        exit_with_errors("Tests execution failed. Fix the errors and run again.")
+      # The version number from the file
+      #
+      # @return [String] the version number
+      def old_version_number
+        File.read(DECIDIM_VERSION_FILE).strip
       end
-    end
 
-    # Generates the changelog taking into account the last time the version changed
-    #
-    # @return [void]
-    def generate_changelog
-      sha_version = capture("git log -n 1 --pretty=format:%h -- .decidim-version")[0]
-      ChangeLogGenerator.new(token: @token, since_sha: sha_version).call
-      temporary_changelog = File.read("./temporary_changelog.md")
-      legacy_changelog = File.read("./CHANGELOG.md")
-      version_changelog = "## [#{version_number}](https://github.com/decidim/decidim/tree/#{version_number})\n\n#{temporary_changelog}\n"
-      changelog = legacy_changelog.gsub("# Changelog\n\n", "# Changelog\n\n#{version_changelog}")
-      File.write("./CHANGELOG.md", changelog)
-    end
+      # Run the tests and if fails restore the changes using git and exit with an error
+      #
+      # @return [void]
+      def check_tests
+        puts "Running specs"
+        output, status = capture("bin/rspec")
 
-    # Creates the pull request for bumping the version
-    #
-    # @return [void]
-    def create_pull_request
-      base_branch = release_branch
-      head_branch = "chore/prepare/#{version_number}"
+        unless status.success?
+          run("git restore .")
+          puts output
+          exit_with_errors("Tests execution failed. Fix the errors and run again.")
+        end
+      end
 
-      params = {
-        title: "Bump to v#{version_number} version",
-        body: "#### :tophat: What? Why?
+      # Generates the changelog taking into account the last time the version changed
+      #
+      # @return [void]
+      def generate_changelog
+        sha_version = capture("git log -n 1 --pretty=format:%h -- .decidim-version")[0]
+        ChangeLogGenerator.new(token: @token, since_sha: sha_version).call
+        temporary_changelog = File.read("./temporary_changelog.md")
+        legacy_changelog = File.read("./CHANGELOG.md")
+        version_changelog = "## [#{version_number}](https://github.com/decidim/decidim/tree/#{version_number})\n\n#{temporary_changelog}\n"
+        changelog = legacy_changelog.gsub("# Changelog\n\n", "# Changelog\n\n#{version_changelog}")
+        File.write("./CHANGELOG.md", changelog)
+      end
+
+      # Creates the pull request for bumping the version
+      #
+      # @return [void]
+      def create_pull_request
+        base_branch = release_branch
+        head_branch = "chore/prepare/#{version_number}"
+
+        params = {
+          title: "Bump to v#{version_number} version",
+          body: "#### :tophat: What? Why?
 
 This PR changes the version of the #{release_branch} branch, so we can publish the release once this is approved and merged.
 
@@ -218,68 +219,69 @@ You will see errors such as `No matching version found for @decidim/browserslist
 
 :hearts: Thank you!
         ",
-        labels: ["type: internal"],
-        head: head_branch,
-        base: base_branch
-      }
-      Decidim::MaintainersToolbox::GithubManager::Poster.new(token: @token, params: params).call
-    end
+          labels: ["type: internal"],
+          head: head_branch,
+          base: base_branch
+        }
+        Decidim::MaintainersToolbox::GithubManager::Poster.new(token: @token, params: params).call
+      end
 
-    # Captures to output of a command
-    #
-    # @return [Array<String, Process::Status>] The stdout and stderr of the command and its status (aka error code)
-    def capture(cmd, env: {})
-      Open3.capture2e(env, cmd)
-    end
+      # Captures to output of a command
+      #
+      # @return [Array<String, Process::Status>] The stdout and stderr of the command and its status (aka error code)
+      def capture(cmd, env: {})
+        Open3.capture2e(env, cmd)
+      end
 
-    # Runs a command
-    #
-    # @return [void]
-    def run(cmd, out: $stdout)
-      system(cmd, out: out)
-    end
+      # Runs a command
+      #
+      # @return [void]
+      def run(cmd, out: $stdout)
+        system(cmd, out: out)
+      end
 
-    # Check if there is any open pull request from Crowdin in GitHub
-    #
-    # @return [Boolean] - true if there is any open PR
-    def pending_crowdin_pull_requests?
-      pull_requests = Decidim::MaintainersToolbox::GithubManager::Querier::ByTitle.new(token: @token, title: "New Crowdin updates").call
-      pull_requests.any?
-    end
+      # Check if there is any open pull request from Crowdin in GitHub
+      #
+      # @return [Boolean] - true if there is any open PR
+      def pending_crowdin_pull_requests?
+        pull_requests = Decidim::MaintainersToolbox::GithubManager::Querier::ByTitle.new(token: @token, title: "New Crowdin updates").call
+        pull_requests.any?
+      end
 
-    # Exit the script execution if there are any pull request from Crowdin open
-    #
-    # @return [void]
-    def exit_if_pending_crowdin_pull_request
-      return unless pending_crowdin_pull_requests?
+      # Exit the script execution if there are any pull request from Crowdin open
+      #
+      # @return [void]
+      def exit_if_pending_crowdin_pull_request
+        return unless pending_crowdin_pull_requests?
 
-      error_message = <<-EOERROR
+        error_message = <<-EOERROR
   There are open pull requests from Crowdin in GitHub
   Merge them and run again this script.
-      EOERROR
-      exit_with_errors(error_message)
-    end
+        EOERROR
+        exit_with_errors(error_message)
+      end
 
-    # Exit the script execution with a message
-    # Exit the script execution if there are any unstaged changes
-    #
-    # @return [void]
-    def exit_if_unstaged_changes
-      return if `git diff`.empty?
+      # Exit the script execution with a message
+      # Exit the script execution if there are any unstaged changes
+      #
+      # @return [void]
+      def exit_if_unstaged_changes
+        return if `git diff`.empty?
 
-      error_message = <<-EOERROR
+        error_message = <<-EOERROR
   There are changes not staged in your project.
   Please commit your changes or stash them.
-      EOERROR
-      exit_with_errors(error_message)
-    end
+        EOERROR
+        exit_with_errors(error_message)
+      end
 
-    # Exit the script execution with a message
-    #
-    # @return [void]
-    def exit_with_errors(message)
-      puts message
-      exit 1
+      # Exit the script execution with a message
+      #
+      # @return [void]
+      def exit_with_errors(message)
+        puts message
+        exit 1
+      end
     end
   end
 end


### PR DESCRIPTION
When trying to call the executable file, i get the following errror. This PR fixes it. 

```bash
~/Sites/decidim/decidim-maintainers_toolbox/exe$ ./decidim-backporter
Traceback (most recent call last):
	6: from ./decidim-backporter:6:in `<main>'
	5: from ./decidim-backporter:6:in `require_relative'
	4: from /home/alecslupu/Sites/decidim/decidim-maintainers_toolbox/lib/decidim/maintainers_toolbox/github_manager/querier.rb:6:in `<top (required)>'
	3: from /home/alecslupu/Sites/decidim/decidim-maintainers_toolbox/lib/decidim/maintainers_toolbox/github_manager/querier.rb:6:in `require_relative'
	2: from /home/alecslupu/Sites/decidim/decidim-maintainers_toolbox/lib/decidim/maintainers_toolbox/github_manager/querier/by_issue_id.rb:3:in `<top (required)>'
	1: from /home/alecslupu/Sites/decidim/decidim-maintainers_toolbox/lib/decidim/maintainers_toolbox/github_manager/querier/by_issue_id.rb:3:in `require_relative'
/home/alecslupu/Sites/decidim/decidim-maintainers_toolbox/lib/decidim/maintainers_toolbox/github_manager/querier/base.rb:7:in `<top (required)>': uninitialized constant Decidim (NameError)
```

The PR essetially, fixes the namespacing The following  
```
module Decidim::MaintainersToolbox
  # code
end 
```
is being transformed into : 
```
module Decidim
  module MaintainersToolbox
    # code
  end 
end
```
And also, the code has been indented to match new structure. 