### PR TITLE
Hide merged PRs from backports-checker reports

### DIFF
--- a/lib/decidim/maintainers_toolbox/backports_reporter/report.rb
+++ b/lib/decidim/maintainers_toolbox/backports_reporter/report.rb
@@ -27,6 +27,8 @@ module Decidim
         def output_report
           output = output_head
           report.each do |line|
+            next if backports_merged?(line[:related_issues])
+
             output += output_line(line)
           end
           output
@@ -47,6 +49,17 @@ module Decidim
           return if related_issues.empty?
 
           related_issues.first
+        end
+
+        def backports_merged?(related_issues)
+          return if related_issues.empty?
+
+          latest_pr = extract_backport_pull_request_for_version(related_issues, "v#{last_version_number}")
+          penultimate_pr = extract_backport_pull_request_for_version(related_issues, "v#{penultimate_version_number}")
+
+          return unless [latest_pr, penultimate_pr].all?
+
+          latest_pr[:state] == "merged" && penultimate_pr[:state] == "merged"
         end
       end
     end

--- a/spec/lib/decidim/maintainers_toolbox/backports_reporter/cli_report_spec.rb
+++ b/spec/lib/decidim/maintainers_toolbox/backports_reporter/cli_report_spec.rb
@@ -100,11 +100,10 @@ describe Decidim::MaintainersToolbox::BackportsReporter::CLIReport do
           ]
         end
 
-        it "returns a valid response" do
+        it "hides row when both PRs are merged" do
           response = <<~RESPONSE
             |   ID   |                                        Title                                        | Backport v0.27 | Backport v0.26 |
             |--------|-------------------------------------------------------------------------------------|----------------|----------------|
-            | #10234 | Fix the world                                                                       |      \e[34m#9875\e[0m     |      \e[34m#9876\e[0m     |
           RESPONSE
           expect(subject).to eq response
         end


### PR DESCRIPTION
This PR hides the backports already merged from the backports-checker. 

### Before
The list is so big, and is not fit in 1 screen. 
![image](https://github.com/decidim/decidim-maintainers_toolbox/assets/105683/67976adf-a960-41b4-a5be-fc52991a9995)

### After 
![image](https://github.com/decidim/decidim-maintainers_toolbox/assets/105683/d1d4bc1c-9437-4418-a92a-f83bb6fd9056)
