### PR TITLE
Fix activesupport dependency requirement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     decidim-maintainers_toolbox (0.1.0)
+      activesupport (~> 6.1.7)
       faraday (~> 1.10)
       ruby-progressbar (~> 1.7)
       thor (~> 1.0)
@@ -81,7 +82,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activesupport (~> 6.1.7)
   decidim-maintainers_toolbox!
   rake (~> 13.0)
   rspec (~> 3.12)

--- a/decidim-maintainers_toolbox.gemspec
+++ b/decidim-maintainers_toolbox.gemspec
@@ -37,11 +37,11 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "activesupport", "~> 6.1.7"
   spec.add_dependency "faraday", "~> 1.10"
   spec.add_dependency "ruby-progressbar", "~> 1.7"
   spec.add_dependency "thor", "~> 1.0"
 
-  spec.add_development_dependency "activesupport", "~> 6.1.7"
   spec.add_development_dependency "rspec", "~> 3.12"
   spec.add_development_dependency "webmock", "~> 3.18"
 end


### PR DESCRIPTION
While working with the gem, I realized that I made a mistake with the activesupport requirement, as I've added it as a development requirement but it's actually also for production usage:

```console
$ grep -r active_support lib/
lib/decidim/maintainers_toolbox/github_manager/poster.rb:require "active_support/core_ext/hash/except"
lib/decidim/maintainers_toolbox/github_manager/querier/by_label.rb:require "active_support/core_ext/time/zones"
lib/decidim/maintainers_toolbox/backports_reporter/cli_report.rb:require "active_support/core_ext/string/filters"
```

This PR fixes this error. We should do a release after merging this (v0.2.0) 

## Testing 

To check the bug: 

Start with a new version of ruby without any gem installed (only the default ones)
Install `decidim-maintainers_toolbox` gem: `gem install decidim-maintainers_toolbox`
Try to use the gem
See error

## Stacktrace

```console
$ decidim-backports-checker --github-token=(gh auth token) --last-version-number 0.28 --days-to-check-from 10
Traceback (most recent call last):
        8: from /home/apereira/.local/share/mise/installs/ruby/2.7.6/bin/decidim-backports-checker:23:in `<main>'
        7: from /home/apereira/.local/share/mise/installs/ruby/2.7.6/bin/decidim-backports-checker:23:in `load'
        6: from /home/apereira/.local/share/mise/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/decidim-maintainers_toolbox-0.1.0/exe/decidim-backports-checker:6:in `<top (required)>'
        5: from /home/apereira/.local/share/mise/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/decidim-maintainers_toolbox-0.1.0/exe/decidim-backports-checker:6:in `require_relative'
        4: from /home/apereira/.local/share/mise/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/decidim-maintainers_toolbox-0.1.0/lib/decidim/maintainers_toolbox/git_backport_checker.rb:5:in `<top (required)>'
        3: from /home/apereira/.local/share/mise/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/decidim-maintainers_toolbox-0.1.0/lib/decidim/maintainers_toolbox/git_backport_checker.rb:5:in `require_relative'
        2: from /home/apereira/.local/share/mise/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/decidim-maintainers_toolbox-0.1.0/lib/decidim/maintainers_toolbox/github_manager/querier/by_label.rb:3:in `<top (required)>'
        1: from /home/apereira/.local/share/mise/installs/ruby/2.7.6/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
/home/apereira/.local/share/mise/installs/ruby/2.7.6/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require': cannot load such file -- active_support/core_ext/time/zones (LoadError)
```