### PR TITLE
Bug fixing for releaser

### DIFF
--- a/lib/decidim/maintainers_toolbox/github_manager/querier.rb
+++ b/lib/decidim/maintainers_toolbox/github_manager/querier.rb
@@ -15,7 +15,7 @@ module Decidim
       module Querier
         autoload :ByIssueId, "decidim/maintainers_toolbox/github_manager/querier/by_issue_id"
         autoload :ByLabel, "decidim/maintainers_toolbox/github_manager/querier/by_label"
-        autoload :ByTitle, "decidim/maintainers_toolbox/github_manager/querier/by_title"
+        autoload :ByQuery, "decidim/maintainers_toolbox/github_manager/querier/by_query"
         autoload :RelatedIssues, "decidim/maintainers_toolbox/github_manager/querier/related_issues"
       end
     end

--- a/lib/decidim/maintainers_toolbox/github_manager/querier/by_query.rb
+++ b/lib/decidim/maintainers_toolbox/github_manager/querier/by_query.rb
@@ -9,7 +9,7 @@ module Decidim
         # Makes a GET request for the list of Issues or Pull Requests in GitHub.
         #
         # @param token [String] token for GitHub authentication
-        # @pparam query [Hash] the query to search
+        # @param query [Hash] the query to search
         #
         # @see https://docs.github.com/en/rest/issues/issues#list-repository-issues GitHub API documentation
         class ByQuery < Decidim::MaintainersToolbox::GithubManager::Querier::Base

--- a/lib/decidim/maintainers_toolbox/github_manager/querier/by_query.rb
+++ b/lib/decidim/maintainers_toolbox/github_manager/querier/by_query.rb
@@ -9,15 +9,13 @@ module Decidim
         # Makes a GET request for the list of Issues or Pull Requests in GitHub.
         #
         # @param token [String] token for GitHub authentication
-        # @param title [String] the title that we want to search by
-        # @param state [String] the state of the issue. By default is "open"
+        # @pparam query [Hash] the query to search
         #
         # @see https://docs.github.com/en/rest/issues/issues#list-repository-issues GitHub API documentation
-        class ByTitle < Decidim::MaintainersToolbox::GithubManager::Querier::Base
-          def initialize(title:, token:, state: "open")
-            @title = title
+        class ByQuery < Decidim::MaintainersToolbox::GithubManager::Querier::Base
+          def initialize(token:, query: {})
             @token = token
-            @state = state
+            @query = query
           end
 
           # Makes the GET request and parses the response of an Issue or Pull Request in GitHub
@@ -31,14 +29,12 @@ module Decidim
 
           private
 
-          attr_reader :title, :state
+          attr_reader :query
 
           def headers
             {
-              title: title,
-              state: state,
               per_page: 100
-            }
+            }.merge(query)
           end
 
           # Parses the response of an Issue or Pull Request in GitHub

--- a/lib/decidim/maintainers_toolbox/releaser.rb
+++ b/lib/decidim/maintainers_toolbox/releaser.rb
@@ -2,7 +2,7 @@
 
 require "open3"
 require_relative "github_manager/poster"
-require_relative "github_manager/querier/by_title"
+require_relative "github_manager/querier/by_query"
 require_relative "changelog_generator"
 
 module Decidim
@@ -248,7 +248,7 @@ You will see errors such as `No matching version found for @decidim/browserslist
       #
       # @return [Boolean] - true if there is any open PR
       def pending_crowdin_pull_requests?
-        pull_requests = Decidim::MaintainersToolbox::GithubManager::Querier::ByTitle.new(token: @token, title: "New Crowdin updates").call
+        pull_requests = Decidim::MaintainersToolbox::GithubManager::Querier::ByQuery.new(token: @token, query: { title: "New Crowdin updates", creator: "decidim-bot" }).call
         pull_requests.any?
       end
 

--- a/lib/decidim/maintainers_toolbox/releaser.rb
+++ b/lib/decidim/maintainers_toolbox/releaser.rb
@@ -180,7 +180,7 @@ module Decidim
       # @return [void]
       def check_tests
         puts "Running specs"
-        output, status = capture("bin/rspec")
+        output, status = capture("bin/rspec", { "ENFORCED_LOCALES" => "en,ca,es", "SKIP_NORMALIZATION" => "true" })
 
         unless status.success?
           run("git restore .")

--- a/lib/decidim/maintainers_toolbox/releaser.rb
+++ b/lib/decidim/maintainers_toolbox/releaser.rb
@@ -37,11 +37,15 @@ module Decidim
 
           run("git checkout #{release_branch}")
           run("git pull origin #{release_branch}")
+
           bump_decidim_version
           run("bin/rake update_versions")
+
           run("bin/rake patch_generators")
+
           run("bin/rake bundle")
           run("npm install")
+          run("bin/rake webpack") if Dir.exists?("decidim_app-design")
 
           check_tests
 

--- a/spec/lib/decidim/maintainers_toolbox/github_manager/querier/by_query_spec.rb
+++ b/spec/lib/decidim/maintainers_toolbox/github_manager/querier/by_query_spec.rb
@@ -3,12 +3,12 @@
 require "decidim/maintainers_toolbox/github_manager/querier"
 require "webmock/rspec"
 
-describe Decidim::MaintainersToolbox::GithubManager::Querier::ByTitle do
-  let(:querier) { described_class.new(token: "abc", title: title, state: state) }
-  let(:title) { "Fix whatever" }
-  let(:state) { "open" }
+describe Decidim::MaintainersToolbox::GithubManager::Querier::ByQuery do
+  let(:querier) { described_class.new(token: @token, query: { title: "Fix whatever" }) }
 
-  let(:stubbed_url) { "https://api.github.com/repos/decidim/decidim/issues?per_page=100&state=open&title=Fix%20whatever" }
+  let(:title) { "Fix whatever" }
+
+  let(:stubbed_url) { "https://api.github.com/repos/decidim/decidim/issues?per_page=100&title=Fix%20whatever" }
   let(:stubbed_headers) { {} }
 
   before do


### PR DESCRIPTION
A couple bugs that I found when doing the last patch release that I had pending: 

- in v0.27 we still have the rake webpack script that needs to be run during the releases
- the ByTitle (for checking the "New crowdin translations" PRs) wasn't working correctly. I refactored it to ByQuery to make it also more useful and not coupled to only that case
- when running the rspec suite locally, it's fundamental to have the environment variables to detect i18n sanity issues not only with English but also with Spanish and Catalan (the mandatory languages for the releases)