### PR TITLE
Make directory check compatible with latest versions of ruby

### DIFF
--- a/lib/decidim/maintainers_toolbox/releaser.rb
+++ b/lib/decidim/maintainers_toolbox/releaser.rb
@@ -45,7 +45,7 @@ module Decidim
 
           run("bin/rake bundle")
           run("npm install")
-          run("bin/rake webpack") if Dir.exists?("decidim_app-design")
+          run("bin/rake webpack") if Dir.exist?("decidim_app-design")
 
           check_tests
 


### PR DESCRIPTION
With latest versions of Ruby, `Dir.exists?` doesn't exist anymore, so we need to use `Dir.exist?`. 

Mind that in older versions of Ruby both methods exists, so this would be right.

I checked it out in 

3.1.1 (the version that we use in v0.28) 
3.0.2 (the version that we use in v0.27)

 