### PR TITLE
Changed the apply patch order, most recent version is applied first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2025-04-25
+
+### Changed 
+
+- Changed the order in which the backports are handled, most recent version if first 
+
 ## [0.7.0] - 2025-02-11
 
 ### Changed

--- a/lib/decidim/maintainers_toolbox/action_backporter.rb
+++ b/lib/decidim/maintainers_toolbox/action_backporter.rb
@@ -65,7 +65,7 @@ module Decidim
 
         pull_request_metadata[:labels].map do |item|
           item.match(/release: v(\d+\.\d+)/) { |m| m[1] }
-        end.compact
+        end.compact.reverse
       end
 
       # Asks the metadata for a given issue or pull request on GitHub API

--- a/lib/decidim/maintainers_toolbox/version.rb
+++ b/lib/decidim/maintainers_toolbox/version.rb
@@ -2,6 +2,6 @@
 
 module Decidim
   module MaintainersToolbox
-    VERSION = "0.7.0"
+    VERSION = "0.7.1"
   end
 end

--- a/spec/lib/decidim/maintainers_toolbox/action_backporter_spec.rb
+++ b/spec/lib/decidim/maintainers_toolbox/action_backporter_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Decidim::MaintainersToolbox::ActionBackporter do
   describe ".extract_versions" do
     it "returns the versions" do
       allow(subject).to receive(:pull_request_metadata).and_return({ labels: ["type: fix", "release: v0.28", "release: v0.29"], is_merged: true })
-      expect(subject.send(:extract_versions)).to eq(["0.28", "0.29"])
+      expect(subject.send(:extract_versions)).to eq(["0.29", "0.28"])
       expect(subject.send(:extract_versions).size).to eq(2)
     end
 


### PR DESCRIPTION
During operations, i have seen a lot of backports are not automatically as the app is failing with conflicts in oldest release.
This PR is changing the order of patch applying from most recent to oldest.  