### PR TITLE
Fix minor release process bug

### DIFF
--- a/lib/decidim/maintainers_toolbox/releaser.rb
+++ b/lib/decidim/maintainers_toolbox/releaser.rb
@@ -32,6 +32,9 @@ module Decidim
           case @version_type
           when "rc"
             release = ReleaseCandidateVersion.new(token: @token, working_dir: @working_dir)
+          # Minor release process is the same as the Patch release process
+          when "minor"
+            release = ReleasePatchVersion.new(token: @token, working_dir: @working_dir)
           when "patch"
             release = ReleasePatchVersion.new(token: @token, working_dir: @working_dir)
           else


### PR DESCRIPTION
While doing the release for v0.30, I had the error "This is not a valid version type".

I realized that most of the code allows a minor release, but we don't have the `ReleaseMinorVersion` class. The thing is that much of the process is the same as an actual patch release, and we even have the code for generating the minor version number there, so we don't need any more. 

https://github.com/decidim/decidim-maintainers_toolbox/blob/6354a98f329de8913c75f0a8041269607066b78d/exe/decidim-releaser#L14
https://github.com/decidim/decidim-maintainers_toolbox/blob/6354a98f329de8913c75f0a8041269607066b78d/lib/decidim/maintainers_toolbox/releaser.rb#L17
https://github.com/decidim/decidim-maintainers_toolbox/blob/6354a98f329de8913c75f0a8041269607066b78d/lib/decidim/maintainers_toolbox/release_patch_version.rb#L95

I even did the v0.30.0 release by passing the version_type=patch to the `decidim-releaser` script :) 

This PR adds the minor release explicitly so we can do that officially. 