### PR TITLE
Add comment about the official releases notes in the markdown working file

### DIFF
--- a/lib/decidim/maintainers_toolbox/release_candidate_version.rb
+++ b/lib/decidim/maintainers_toolbox/release_candidate_version.rb
@@ -219,6 +219,9 @@ EOCHANGELOG
 
 ## 1. Upgrade notes
 
+NOTE: This is the draft for the releases notes. If you are an implementer or someone that is upgrading a Decidim installation, we recommend
+checking out the last version of this document in the [GitHub page for the releases of this branch](https://github.com/decidim/decidim/releases/).
+
 As usual, we recommend that you have a full backup, of the database, application code and static files.
 
 To update, follow these steps:


### PR DESCRIPTION

Back in https://github.com/decidim/decidim/pull/13933 we added a comment to the Releases Notes about the officiailty of the markdown file vs the GH Releases feature. This PR adds this comment in the generator so it is always in this file. 